### PR TITLE
ci: only commit sponsor updates on schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           SPONSORKIT_OPENCOLLECTIVE_KEY: ${{ secrets.SPONSORKIT_OPENCOLLECTIVE_KEY }}
 
       - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
+        if: github.event_name == 'schedule'
         with:
           add: "sponsors.*"
           message: "chore: update sponsors"


### PR DESCRIPTION
## Summary
- Daily cron pushes used a PAT, which (unlike `GITHUB_TOKEN`) re-fires workflows on push. Combined with non-deterministic sharp/libwebp WebP output after the v17.1.0 bump pulled sharp 0.34.3 → 0.34.5, this turned the workflow into a self-perpetuating commit loop (e.g. 19 commits ~25s apart on 2026-05-16).
- Gate the `EndBug/add-and-commit` step on `github.event_name == 'schedule'` so push-triggered runs no longer commit, breaking the loop. The job itself still runs on push/PR for validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)