### PR TITLE
ci: pin VIPS_CONCURRENCY=1 for deterministic WebP encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           SPONSORKIT_GITHUB_TOKEN: ${{ secrets.SPONSORKIT_GITHUB_TOKEN }}
           SPONSORKIT_OPENCOLLECTIVE_KEY: ${{ secrets.SPONSORKIT_OPENCOLLECTIVE_KEY }}
+          VIPS_CONCURRENCY: 1
 
       - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:


### PR DESCRIPTION
## Summary
- sharp on linux-x64 intermittently emits different VP8 bitstreams for the same input avatar. Inspecting consecutive `sponsors.json` commits showed ~19 of 56 GitHub avatar buffers flipping between two valid WebP encodes (e.g. erictaylor at 2022 vs 2026 bytes). The same encode on darwin-arm64 is bit-stable across 30+ runs at every concurrency level.
- Source bytes from `avatars.githubusercontent.com` are byte-identical across fetches, and sponsorkit's clipPath id is `md5(base64)` — so the divergence is inside libvips/libwebp on linux-x64.
- Setting `VIPS_CONCURRENCY=1` forces libvips single-threaded, which avoids the race. `sharp.concurrency()` honors the env var (verified locally — drops to 1 immediately).

Slightly slower build, but should make the encoder output reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)